### PR TITLE
Support for blade files when Laravel Blade Snippets extension installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,10 @@
             {
               "language": "php",
               "path": "./snippets/snippets.json"
+            },
+            {
+              "language": "blade",
+              "path": "./snippets/snippets.json"
             }
         ]
     }


### PR DESCRIPTION
When [Laravel Blade Snippets](https://github.com/onecentlin/laravel-blade-snippets-vscode) extension is installed the .blade.php files language aren't marked as "php" files anymore, instead as "blade" language.